### PR TITLE
Add TyVarBndr flag param for template-haskell >= 2.17.0.0

### DIFF
--- a/Data/Generics/Traversable/TH.hs
+++ b/Data/Generics/Traversable/TH.hs
@@ -111,6 +111,12 @@ conA (ForallC _ _ c)  = conA c
 conA (RecC c xs)      = (c, length xs, map (\(_,_,t)->t) xs)
 conA _ = err "GADTs are not supported yet"
 
+#if MIN_VERSION_template_haskell(2,17,0)
+varName :: TyVarBndr flag -> Name
+varName (PlainTV n _) = n
+varName (KindedTV n _ _) = n
+#else
 varName :: TyVarBndr -> Name
 varName (PlainTV n) = n
 varName (KindedTV n _) = n
+#endif


### PR DESCRIPTION
Allow compile library with latest (at the moment `template-haskell` version 2.17.0.0).